### PR TITLE
fix!: Remove caching of services from container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "require-dev": {
         "phpstan/phpstan": "^1.9",
         "friendsofphp/php-cs-fixer": "^3.14",
-        "mockery/mockery": "^1.5",
         "phpstan/phpstan-mockery": "^1.1",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0",
+        "mockery/mockery": "^1.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9fbb38995010710e0b756b06a59f611",
+    "content-hash": "8afddd9541270acbf3778054ee1d3f73",
     "packages": [
         {
             "name": "psr/container",
@@ -575,38 +575,38 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.5.1",
+            "version": "1.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e"
+                "reference": "0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06",
+                "reference": "0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "conflict": {
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.3"
+                "phpunit/phpunit": "^8.5 || ^9.6.10",
+                "symplify/easy-coding-standard": "^12.0.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -617,12 +617,20 @@
                 {
                     "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
                 },
                 {
                     "name": "Dave Marshall",
                     "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
                 }
             ],
             "description": "Mockery is a simple yet flexible PHP mock object framework",
@@ -640,10 +648,13 @@
                 "testing"
             ],
             "support": {
+                "docs": "https://docs.mockery.io/",
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.5.1"
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
             },
-            "time": "2022-09-07T15:32:08+00:00"
+            "time": "2023-12-10T02:24:34+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/Facade.php
+++ b/src/Facade.php
@@ -136,13 +136,13 @@ abstract class Facade
     {
         $accessor = static::getFacadeAccessor();
         $mock = static::createMock();
-        self::$resolvedInstances[$accessor] = $mock;
+        static::$resolvedInstances[$accessor] = $mock;
 
         return $mock;
     }
 
     /**
-     * Set the container instance.
+     * Set the container instance. Reset any cache instances in the process.
      *
      * @codeCoverageIgnore
      *
@@ -151,6 +151,8 @@ abstract class Facade
      */
     public static function setContainer(ContainerInterface $container): void
     {
+        static::clear();
+
         static::$container = $container;
     }
 

--- a/tests/Unit/FacadeTest.php
+++ b/tests/Unit/FacadeTest.php
@@ -161,4 +161,21 @@ class FacadeTest extends TestCase
         $result = ServiceFacade::greeting('World'); // @phpstan-ignore-line
         $this->assertEquals('Hello World!', $result);
     }
+
+    public function testSettingContainerClearsFacadeCache(): void
+    {
+        $firstService = new Service();
+        $firstContainer = new Container($firstService);
+        ServiceFacade::setContainer($firstContainer);
+        $firstRoot = ServiceFacade::getFacadeRoot();
+        $this->assertSame($firstRoot, $firstService);
+
+        $secondService = new Service();
+        $secondContainer = new Container($secondService);
+        ServiceFacade::setContainer($secondContainer);
+        $secondRoot = ServiceFacade::getFacadeRoot();
+        $this->assertSame($secondRoot, $secondService);
+
+        $this->assertNotSame($firstRoot, $secondRoot);
+    }
 }

--- a/tests/Unit/FacadeTest.php
+++ b/tests/Unit/FacadeTest.php
@@ -117,49 +117,30 @@ class FacadeTest extends TestCase
         ServiceFacade::invalid(); // @phpstan-ignore-line
     }
 
-    public function testGetMockableClass(): void
+    public function testGetFacadeRootUsesSwappedValueWithoutContainer(): void
     {
-        // Given
-        ServiceFacade::setContainer($this->container);
+        $service = new Service();
+        ServiceFacade::swap($service);
 
-        // When
-        $result = ServiceFacade::getMockableClass();
+        $root = ServiceFacade::getFacadeRoot();
 
-        // Then
-        $this->assertSame(Service::class, $result);
+        $this->assertSame($root, $service);
     }
 
-    public function testCreateMock(): void
+    public function testSwap(): void
     {
         // Given
         ServiceFacade::setContainer($this->container);
 
-        // When
-        $mock = ServiceFacade::createMock();
+        $root = ServiceFacade::getFacadeRoot();
+        $this->assertSame($this->service, $root);
 
-        // Then
-        $this->assertInstanceOf(Mockery\MockInterface::class, $mock);
-    }
+        $otherService = new Service();
+        ServiceFacade::swap($otherService);
 
-    public function testSwapMock(): void
-    {
-        // Given
-        ServiceFacade::setContainer($this->container);
-
-        // When
-        $mock = ServiceFacade::swapMock();
-        $mock->shouldReceive('greeting')->andReturn('Hello Mock!');
-
-        // Then
-        $this->assertInstanceOf(Mockery\MockInterface::class, $mock);
-
-        $result = ServiceFacade::greeting('World'); // @phpstan-ignore-line
-        $this->assertEquals('Hello Mock!', $result);
-
-        ServiceFacade::clear();
-        ServiceFacade::setContainer($this->container);
-        $result = ServiceFacade::greeting('World'); // @phpstan-ignore-line
-        $this->assertEquals('Hello World!', $result);
+        $otherRoot = ServiceFacade::getFacadeRoot();
+        $this->assertSame($otherRoot, $otherService);
+        $this->assertNotSame($root, $otherRoot);
     }
 
     public function testSettingContainerClearsFacadeCache(): void


### PR DESCRIPTION
While using the container facade in the  [HasPolicies trait](https://github.com/geekcell/user-policy-bundle/blob/main/src/Trait/HasPolicies.php) of the [user-policy-bundle](https://github.com/geekcell/user-policy-bundle) I noticed that the facade would return a cached instance of the `PolicyRegistry` which included a stale(?) reference to a ManagerRegistry while running our integration tests. This seems to have been caused by the cached dependencies of the `Facade` class.

In order to fix this there were two approaches to this:
1. Remove the caching of dependencies
2. Add a function to check whether a facade class is cachable

Option 1 could have backwards compatibility breaking and implicit while Option 2 is more explicit and definitely keeps BC.

After talking and fiddling around with @janvt we came to the conclusion that it makes sense to get rid of the caching and instead only check for "swapped instances".

This change should result in a major version bump as a few methods are removed and the caching behaviour could've been interpreted as intended behaviour instead.